### PR TITLE
vnc: cannot have two containers running at once

### DIFF
--- a/vnc/files/start-vnc-server.sh
+++ b/vnc/files/start-vnc-server.sh
@@ -5,7 +5,15 @@ if [[ -z "${BAXTER_HOSTNAME:-}" || "${BAXTER_HOSTNAME}" == "baxter_hostname.loca
   exit 1
 fi
 
-export DISPLAY=:20
+# Set the VNC port number based on environment variable or default to 5900
+port="${VNC_PORT:-5900}"
+
+# Set the display number based on the VNC port
+# (e.g. 5900 -> :20, 5901 -> :21, etc.)
+display_number=$((port - 5880))
+export DISPLAY=":${display_number}"
+
+echo "--- Starting on VNC Port ${port} (X Display ${DISPLAY}) ---"
 
 # Start the X server
 Xvfb "$DISPLAY" -screen 0 "${DISPLAY_GEOMETRY}x24" &
@@ -16,8 +24,7 @@ xfdesktop &
 xfwm4 &
 xterm &
 
-port="${VNC_PORT:-5900}"
-
+# Assign arguments for x11vnc
 args=(
   -display "${DISPLAY}"
   -rfbport "${port}"
@@ -30,4 +37,5 @@ if [[ -n "${VNC_PASSWORD}" ]]; then
   args+=( -passwd "${VNC_PASSWORD}" )
 fi
 
+# Start the VNC server
 exec x11vnc "${args[@]}"

--- a/vnc/files/start-vnc-server.sh
+++ b/vnc/files/start-vnc-server.sh
@@ -17,6 +17,7 @@ echo "--- Starting on VNC Port ${port} (X Display ${DISPLAY}) ---"
 
 # Start the X server
 Xvfb "$DISPLAY" -screen 0 "${DISPLAY_GEOMETRY}x24" &
+sleep 1 # Give Xvfb time to start
 
 # Start the xfce environment
 xfce4-panel &
@@ -24,10 +25,13 @@ xfdesktop &
 xfwm4 &
 xterm &
 
-# Assign arguments for x11vnc
+sleep 1 # Give Xfce time to start
+
+# Assign arguments for X11vnc
 args=(
   -display "${DISPLAY}"
   -rfbport "${port}"
+  -rfbportv6 "${port}"
   -forever
   -localhost
 )


### PR DESCRIPTION
* Sets the display number based on the VNC port which avoids X server port reuse.
* Sets the TCP6 port for the VNC server which prevents the VNC servers reusing the default (5900).

Fixes #7.